### PR TITLE
personal instance changes, potentially useful to main repo

### DIFF
--- a/autiobooks/autiobooks.py
+++ b/autiobooks/autiobooks.py
@@ -175,12 +175,12 @@ def start_gui():
                 font=('Arial', 12)
             )
             play_label.pack(side="left")
-
+            
             file_name_label = tk.Label(
-                row_frame,
-                text=chapter.file_name,
-                font=('Arial', 12)
-            )
+                row_frame, 
+                text=chapter.display_name if hasattr(chapter, 'display_name') 
+                    else Path(chapter.file_name).stem.replace('_', ' ').title()
+            )            
             file_name_label.pack(side="left")
 
             word_string = "words" if word_count != 1 else "word"
@@ -254,8 +254,13 @@ def start_gui():
                     text = chapter.extracted_text
                     if i == 1:
                         text = f"{title} by {creator}.\n{text}"
-                    wav_filename = filename.replace('.epub', f'_chapter_{i}.wav')
-                    progress_label.config(text=f"Converting chapter {i} of {len(chapters_selected)}")
+                    chapter_title = getattr(chapter, 'display_name', f"Chapter {i}")
+                    safe_title = "".join(c for c in chapter_title if c.isalnum() or c in " _-")
+                    wav_filename = filename.replace('.epub', f'_{safe_title[:50]}.wav')
+
+                    chapter_name = getattr(chapter, 'display_name', f"Chapter {i}")
+                    progress_label.config(text=f"Converting: {chapter_name[:30]}...")
+                    
                     if convert_text_to_wav_file(text, voice,
                                                 speed, wav_filename):
                         wav_files.append(wav_filename)

--- a/autiobooks/autiobooks.py
+++ b/autiobooks/autiobooks.py
@@ -84,7 +84,7 @@ def start_gui():
         values=voices_emojified,
         state="readonly"
     )
-    voice_combo.set(voices[0])  # Set default selection
+    voice_combo.set(voices_emojified[0])  # Set default selection
     voice_combo.pack(side=tk.LEFT, pady=10, padx=5)
     
     pygame.mixer.init()
@@ -288,6 +288,7 @@ def start_gui():
             print(warning)
             # create a warning message box to say this
             messagebox.showwarning("Warning", warning)
+            return
 
         if file_label.cget("text"):
             file_path = file_label.cget("text")


### PR DESCRIPTION
This PR refines chapter presentation, file naming, and content extraction in the audiobook conversion pipeline. NOTE: this was heavily vibecoded several months ago, if any changes are requested or required, I'll probably start over entirely.

## `autiobooks.py`

- Chapter names in the UI now prefer `display_name`, with a fallback that humanizes raw filenames (underscore→space, title-case).
- Progress messages use real chapter names rather than numeric placeholders.
- Output WAV files adopt descriptive names (`BookName_Introduction.wav`), replacing the generic `_chapter_1.wav` pattern.
- Chapter names are sanitized to safe characters (alphanumeric, space, underscore, hyphen) and trimmed to 50 characters.

## `engine.py`

- Introduces `extract_chapter_content()`, which preserves structural elements such as headings, lists, and special blocks.
- Headings are normalized using Markdown prefixes; lists use bullet markers; epigraphs are labeled explicitly.
- `process_chapter()` now unifies title extraction and content extraction.
- TOC and navigation files are more reliably detected and omitted.
- Faulty chapters are skipped safely via expanded try/except handling with error logging.