### PR TITLE
Add support for spanish voice generation

### DIFF
--- a/autiobooks/autiobooks.py
+++ b/autiobooks/autiobooks.py
@@ -78,7 +78,6 @@ def start_gui():
     voice_label.pack(side=tk.LEFT, pady=5, padx=5)
 
     # add a combo box with voice options
-    # filter out the non-english voices (not working yet)
     voice_combo = ttk.Combobox(
         voice_frame,
         values=voices_emojified,

--- a/autiobooks/engine.py
+++ b/autiobooks/engine.py
@@ -13,6 +13,7 @@ from kokoro import KPipeline
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from concurrent.futures import ThreadPoolExecutor
 from PIL import Image, ImageTk
+from .voices_lang import get_language_from_voice
 
 
 SAMPLE_RATE = 24000
@@ -46,8 +47,9 @@ def create_pipeline(lang_code):
         builtins.open = original_open
 
 def gen_audio_segments(text, voice, speed, split_pattern=r'\n+'):
-    # a for american or b for british etc.
-    pipeline = create_pipeline(voice[0])
+    # Get proper language code from voice instead of just first character
+    lang_code = get_language_from_voice(voice)
+    pipeline = create_pipeline(lang_code)
     audio_segments = []
     speed = float(speed)
     for gs, ps, audio in pipeline(text, voice=voice, speed=speed,

--- a/autiobooks/voices_lang.py
+++ b/autiobooks/voices_lang.py
@@ -107,6 +107,6 @@ def deemojify_voice(voice):
     return voice
 
 
-# filter out non-english voices (they're not working yet)
-voices = [x for x in voices_internal if x.startswith("a") or x.startswith("b")]
+# Include English (a, b) and Spanish (e) voices
+voices = [x for x in voices_internal if x.startswith("a") or x.startswith("b") or x.startswith("e")]
 voices_emojified = [emojify_voice(x) for x in voices]


### PR DESCRIPTION
# Add Spanish Voice Support to Autiobooks 

## Overview
This PR enables Spanish language support for Autiobooks, allowing users to generate audiobooks using Spanish voices from the Kokoro TTS model. The changes include enabling Spanish voices in the UI and fixing a critical bug in the TTS pipeline that was preventing proper language code detection.

## Problem
While Kokoro TTS supported Spanish, Autiobooks only exposed English voices (American and British).

## Testing
To verify Spanish support works:

1. Launch Autiobooks GUI
2. Look for voices with 🇪🇸 flag in the voice dropdown
3. Select a Spanish voice (e.g., em_santa)
4. Select an EPUB file
5. Click "Convert epub"
6. Verify audio generates properly with Spanish pronunciation